### PR TITLE
fix: 모바일 상세 게시글 링크 작성 시 깨짐현상 해결

### DIFF
--- a/pyeon_front/src/styles/jobDetail.css
+++ b/pyeon_front/src/styles/jobDetail.css
@@ -46,6 +46,10 @@
   border-radius: 0.25rem;
   background-color: rgba(59, 130, 246, 0.1);
   transition: all 0.2s;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  display: inline-block;
+  max-width: 100%;
 }
 
 .job-content a:hover {

--- a/pyeon_front/src/utils/imageUpload.ts
+++ b/pyeon_front/src/utils/imageUpload.ts
@@ -10,7 +10,6 @@ import { getImageUrl } from "./imageUrl";
  */
 export const uploadImage = async (file: File): Promise<string> => {
   try {
-    // 1. Presigned URL 요청
     const presignedUrlResponse = await axiosInstance.post(
       "/api/images/presigned-url",
       null,
@@ -23,14 +22,12 @@ export const uploadImage = async (file: File): Promise<string> => {
 
     const { preSignedUrl, fileName } = presignedUrlResponse.data;
 
-    // 2. S3에 직접 업로드 (기본 axios 사용, Authorization 헤더 없이)
     await axios.put(preSignedUrl, file, {
       headers: {
         "Content-Type": file.type,
       },
     });
 
-    // 3. 이미지 URL 생성 및 반환 (Cloudflare Workers를 통한 최적화)
     const s3Url = `https://pyeon.s3.ap-northeast-2.amazonaws.com/images/${fileName}`;
     return getImageUrl(s3Url);
   } catch (error) {


### PR DESCRIPTION
모바일에서 링크가 깨지는 문제 해결을 위한 CSS 수정:

1. jobDetail.css 파일의 링크(a 태그) 스타일에 다음 속성 추가:
   - word-break: break-word (긴 단어 자동 줄바꿈)
   - overflow-wrap: break-word (텍스트 오버플로우 방지)
   - display: inline-block (링크 레이아웃 개선)
   - max-width: 100% (컨테이너 너비 초과 방지)

2. 이 변경으로 모바일에서 긴 URL이 화면을 벗어나지 않고 
   적절히 줄바꿈되어 표시됨